### PR TITLE
Align with Zenodo's DOI links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ PENSANT: Parameter estimation helpers
 -------------------------------------
 
 This package provides additional functionality to the lmfit package.
-lmfit :  https://dx.doi.org/10.5281/zenodo.11813
+lmfit :  https://doi.org/10.5281/zenodo.11813
 Its main purpose is to add GUI elements by pyqt graphics.
 It also provides an additional interface to create composite models with automatic naming schemes.
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but since you also mention Zenodo, which started using `https://doi.org` for the DOI links it generates, I'd like to suggest to hereby update the DOI link here as well.

Cheers!